### PR TITLE
DDST-994: Increase allowed image area

### DIFF
--- a/imagemagick_policy.xml
+++ b/imagemagick_policy.xml
@@ -10,8 +10,8 @@
 ]>
 
 <policymap>
-  <policy domain="resource" name="memory" value="1GB"/>
-  <policy domain="resource" name="map" value="1GB"/>
+  <policy domain="resource" name="memory" value="256MiB"/>
+  <policy domain="resource" name="map" value="512MiB"/>
   <policy domain="resource" name="width" value="128KP"/>
   <policy domain="resource" name="height" value="128KP"/>
   <policy domain="resource" name="area" value="256MP"/>


### PR DESCRIPTION
Images exceeding the allowed 128MP have been seen in the wild:

```
F74-B9-E46_Pierce_004.tif[0] TIFF 15093x9900 15093x9900+0+0 16-bit sRGB 855.049MiB 0.000u 0:00.006
F74-B9-E46_Pierce_004.tif[1] TIFF 160x105 160x105+0+0 8-bit sRGB 0.000u 0:00.001
```

`15093 * 9900 = 149420700 ~= 150MP`... let's bump to 256MP to allow a good buffer.