### PR TITLE
FDSF-131: Match Crayfish 4.x expectations

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if curl -s -o /dev/null -w '%{http_code}' localhost/houdini/convert | grep '^401$'; then
+if curl -s -o /dev/null -w '%{http_code}' localhost/houdini/convert | grep '^400$'; then
   echo Success
   exit 0
 else


### PR DESCRIPTION
The check for auth denied isn't a thing with Crayfish 4.x, addressing https://github.com/discoverygarden/crayfish-image/pull/15#discussion_r1951254135