### PR TITLE
ISX-85: Propagate workflows

### DIFF
--- a/.github/workflows/auto-semver.yml
+++ b/.github/workflows/auto-semver.yml
@@ -23,5 +23,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      packages: write
     with:
       tag: ${{ needs.update.outputs.tag }}

--- a/.github/workflows/build-image-from-tag-push.yml
+++ b/.github/workflows/build-image-from-tag-push.yml
@@ -4,6 +4,7 @@ name: Build image from version tag
 permissions:
   id-token: write
   contents: read
+  packages: write
 on:
   push:
     # XXX: Tags pushed via actions (i.e., auto-semver) are not able to trigger additional workflows;
@@ -21,8 +22,9 @@ on:
 jobs:
   build:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
-    uses: discoverygarden/docker-image-reusable-workflows/.github/workflows/build-image.yml@v1
+    uses: discoverygarden/docker-image-reusable-workflows/.github/workflows/build-image.yml@v2
     secrets: inherit
     with:
       image-name: ${{ vars.DOCKER_IMAGE_NAME }}
       tag: ${{ inputs.tag }}
+

--- a/.github/workflows/rebuild-image.yml
+++ b/.github/workflows/rebuild-image.yml
@@ -4,6 +4,7 @@ name: Rebuild image
 permissions:
   id-token: write
   contents: read
+  packages: write
 on:
   schedule:
     - cron: '47 4 1 * *'
@@ -20,7 +21,7 @@ on:
 
 jobs:
   build:
-    uses: discoverygarden/docker-image-reusable-workflows/.github/workflows/build-image.yml@v1
+    uses: discoverygarden/docker-image-reusable-workflows/.github/workflows/build-image.yml@v2
     secrets: inherit
     with:
       env: ${{ inputs.env || github.event_name == 'pull_request' && 'dev' || 'prod' }}


### PR DESCRIPTION
Propagate workflows from https://github.com/discoverygarden/docker-image-workflows/pull/6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflows to grant additional permissions for writing to GitHub Packages.
  - Updated references to use the latest version of the reusable build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->